### PR TITLE
02 recharge money implements async

### DIFF
--- a/common/src/main/java/com/sera/payapp/common/CountDownLatchManager.java
+++ b/common/src/main/java/com/sera/payapp/common/CountDownLatchManager.java
@@ -1,0 +1,37 @@
+package com.sera.payapp.common;
+
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * String Type 의 키값과 CountDownLatch을 value 로 가지는 manager
+ */
+@Configuration
+public class CountDownLatchManager {
+    private final Map<String, CountDownLatch> countDownLatchMap;
+    private final Map<String, String> stringMap;
+
+    public CountDownLatchManager() {
+        this.countDownLatchMap = new HashMap<>();
+        this.stringMap = new HashMap<>();
+    }
+
+    public void addCountDownLatch(String key) {
+        this.countDownLatchMap.put(key, new CountDownLatch(1));
+    }
+
+    public void setDataForKey(String key, String data) {
+        this.stringMap.put(key, data);
+    }
+
+    public String getDataForKey(String key) {
+        return this.stringMap.get(key);
+    }
+
+    public CountDownLatch getCountDownLatch(String key) {
+        return this.countDownLatchMap.get(key);
+    }
+}

--- a/common/src/main/java/com/sera/payapp/common/RechargingMoneyTask.java
+++ b/common/src/main/java/com/sera/payapp/common/RechargingMoneyTask.java
@@ -1,0 +1,40 @@
+package com.sera.payapp.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+//TODO: 고민.. 이거는 money-service 에서 사용하니까, money-service 에서 정의하는게 맞는거 같은데..?
+
+/**
+ * 머니 서비스의 머니총전 API 에서 사용하게 되는 Task 로, 요청된 계좌 체크, 멤버쉽 체크 두 개의 SubTask 를 가지고 있다.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class RechargingMoneyTask {
+    private String taskId;
+    private String taskName;
+    private String membershipId;
+    private List<SubTask> subTasks;
+    // 충전할 금액을 가져오는 게좌
+    private String toBankName;
+    // 충전할 금액에 가져오는 계좌번호
+    private String toBankAccountNumber;
+    private int moneyAmount;
+
+    @Builder
+    public RechargingMoneyTask(String taskName, String membershipId, List<SubTask> subTasks, String toBankName, String toBankAccountNumber, int moneyAmount) {
+        this.taskId = UUID.randomUUID().toString();
+        this.taskName = taskName;
+        this.membershipId = membershipId;
+        this.subTasks = subTasks;
+        this.toBankName = toBankName;
+        this.toBankAccountNumber = toBankAccountNumber;
+        this.moneyAmount = moneyAmount;
+    }
+}

--- a/common/src/main/java/com/sera/payapp/common/SubTask.java
+++ b/common/src/main/java/com/sera/payapp/common/SubTask.java
@@ -1,9 +1,6 @@
 package com.sera.payapp.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * 여러 서비스에서 특정 membershipid 로 Validation을 수행할 때 사용하는 Task
@@ -17,5 +14,16 @@ public class SubTask {
     private String subTaskName;
     // TODO; enum 으로 리팩토링 할 것
     private String taskType; // banking, membership
+    @Setter
     private String status; // success, fail, ready
+
+//    public String getStatus() {
+//        // TODO: 임시로 랜덤하게 성공/실패를 리턴하도록 구현
+//        int iResult = new Random().nextInt(2);
+//        return switch(iResult) {
+//            case 0 ->  "success";
+//            case 1 ->  "fail";
+//            default -> "success";
+//        };
+//    }
 }

--- a/common/src/main/java/com/sera/payapp/common/SubTask.java
+++ b/common/src/main/java/com/sera/payapp/common/SubTask.java
@@ -1,0 +1,21 @@
+package com.sera.payapp.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 여러 서비스에서 특정 membershipid 로 Validation을 수행할 때 사용하는 Task
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class SubTask {
+    private String membershipId;
+    private String subTaskName;
+    // TODO; enum 으로 리팩토링 할 것
+    private String taskType; // banking, membership
+    private String status; // success, fail, ready
+}

--- a/money-service/src/main/java/com/sera/payapp/money/MessageListenerContainerConfig.java
+++ b/money-service/src/main/java/com/sera/payapp/money/MessageListenerContainerConfig.java
@@ -1,0 +1,54 @@
+package com.sera.payapp.money;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sera.payapp.common.CountDownLatchManager;
+import com.sera.payapp.common.LoggingProducer;
+import com.sera.payapp.money.adapter.in.kafka.RechargingMoneyResultConsumer;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class MessageListenerContainerConfig {
+
+    @Value("${kafka.clusters.bootstrapservers}")
+    private String bootstrapServers;
+    @Value("${task.result.topic}")
+    private String topic;
+
+    private final ObjectMapper objectMapper;
+    private final LoggingProducer loggingProducer;
+    private final CountDownLatchManager countDownLatchManager;
+
+    @Bean
+    public KafkaMessageListenerContainer<String, String> kafkaMessageListenerContainer() {
+        ContainerProperties containerProperties = new ContainerProperties(topic);
+        containerProperties.setAckMode(ContainerProperties.AckMode.RECORD);
+        containerProperties.setGroupId("task-result-group");
+        containerProperties.setMessageListener(new RechargingMoneyResultConsumer(objectMapper, loggingProducer, countDownLatchManager));
+        return new KafkaMessageListenerContainer<>(consumerFactory(), containerProperties);
+    }
+
+    public ConsumerFactory<String, String> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(props());
+    }
+
+    private Map<String, Object> props() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return props;
+    }
+}

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/in/kafka/RechargingMoneyResultConsumer.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/in/kafka/RechargingMoneyResultConsumer.java
@@ -1,0 +1,64 @@
+package com.sera.payapp.money.adapter.in.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sera.payapp.common.CountDownLatchManager;
+import com.sera.payapp.common.LoggingProducer;
+import com.sera.payapp.common.RechargingMoneyTask;
+import com.sera.payapp.common.SubTask;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Task 의 결과를 consume 한 후, taskId 에 해당하는 CountDownLatch 를 countDown 한다.
+ * IncreaseMoneyAsyncService 에서는 CountDownLatch 를 await 하고 있고, countDown이 트리거 되면 await 이 풀려 다름 비즈니스 로직을 진행한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RechargingMoneyResultConsumer implements MessageListener<String, String> {
+    private final ObjectMapper objectMapper;
+    private final LoggingProducer loggingProducer;
+    private final CountDownLatchManager countDownLatchManager;
+
+    @Override
+    public void onMessage(ConsumerRecord<String, String> data) {
+        log.info("Received message, key: {}, value: {}", data.key(), data.value());
+        RechargingMoneyTask task;
+        try {
+            task = objectMapper.readValue(data.value(), RechargingMoneyTask.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        List<SubTask> subTaskList = task.getSubTasks();
+
+        boolean taskResult = true;
+        // validation membership
+        // validation banking
+        for (SubTask subTask : subTaskList) {
+            // 한번만 실패해도 실패한 task 로 간주. 모두 성공해야만 성공한 task 로 간주
+            if (subTask.getStatus().equals("fail")) {
+                taskResult = false;
+                break;
+            }
+        }
+
+        // 모두 정상적으로 성공했다면
+        String taskId = task.getTaskId();
+        if (taskResult) {
+            this.loggingProducer.sendMessage(taskId, "task success");
+            this.countDownLatchManager.setDataForKey(taskId, "success");
+        } else {
+            this.loggingProducer.sendMessage(taskId, "task failed");
+            this.countDownLatchManager.setDataForKey(taskId, "failed");
+        }
+
+        this.countDownLatchManager.getCountDownLatch(taskId).countDown();
+
+    }
+}

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/RequestMoneyChangingController.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/RequestMoneyChangingController.java
@@ -8,6 +8,7 @@ import com.sera.payapp.money.application.port.in.IncreaseMoneyUseCase;
 import com.sera.payapp.money.domain.MoneyChangingRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -20,6 +21,7 @@ public class RequestMoneyChangingController {
 
     private final IncreaseMoneyUseCase increaseMoneyUseCase;
 
+    @PostMapping(path = "/money/increase")
     MoneyChangingResultDetail increaseMoneyRequest(@Valid IncreaseMoneyRequest request) {
         MoneyChangingRequest moneyChangingRequest = increaseMoneyUseCase.increaseMoney(new IncreaseMoneyCommand(
                 request.getTargetMembershipId(),

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/RequestMoneyChangingController.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/RequestMoneyChangingController.java
@@ -8,7 +8,9 @@ import com.sera.payapp.money.application.port.in.IncreaseMoneyUseCase;
 import com.sera.payapp.money.domain.MoneyChangingRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -22,12 +24,13 @@ public class RequestMoneyChangingController {
     private final IncreaseMoneyUseCase increaseMoneyUseCase;
 
     @PostMapping(path = "/money/increase")
-    MoneyChangingResultDetail increaseMoneyRequest(@Valid IncreaseMoneyRequest request) {
+    ResponseEntity<MoneyChangingResultDetail> increaseMoneyRequest(@Valid @RequestBody IncreaseMoneyRequest request) {
         MoneyChangingRequest moneyChangingRequest = increaseMoneyUseCase.increaseMoney(new IncreaseMoneyCommand(
                 request.getTargetMembershipId(),
                 request.getAmount()
         ));
-        return MoneyChangingResultDetail.fromMoneyChangingRequest(moneyChangingRequest);
+        var result = MoneyChangingResultDetail.fromMoneyChangingRequest(moneyChangingRequest);
+        return ResponseEntity.ok(MoneyChangingResultDetail.fromMoneyChangingRequest(moneyChangingRequest));
     }
 
 }

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/dto/MoneyChangingResultDetail.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/dto/MoneyChangingResultDetail.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MoneyChangingResultDetail {
     private String moneyChangingRequestId;
-    private ChangingMoneyType moneyChaningType; // 0: 증액, 1: 감액
+    private ChangingMoneyType moneyChangingType; // 0: 증액, 1: 감액
     private MoneyChangingResultStatus moneyChangingResultStatus;
     private int amount;
 

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/dto/MoneyChangingResultDetail.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/in/web/dto/MoneyChangingResultDetail.java
@@ -3,10 +3,12 @@ package com.sera.payapp.money.adapter.in.web.dto;
 import com.sera.payapp.money.domain.ChangingMoneyType;
 import com.sera.payapp.money.domain.MoneyChangingRequest;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class MoneyChangingResultDetail {
     private String moneyChangingRequestId;
     private ChangingMoneyType moneyChaningType; // 0: 증액, 1: 감액

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/out/internal/MembershipServiceAdapter.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/out/internal/MembershipServiceAdapter.java
@@ -1,0 +1,45 @@
+package com.sera.payapp.money.adapter.out.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.sera.payapp.common.CommonHttpClient;
+import com.sera.payapp.money.application.port.out.GetMembershipPort;
+import com.sera.payapp.money.application.port.out.dto.MembershipInfo;
+import com.sera.payapp.money.application.port.out.dto.MembershipStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * membership service (내부 서비스) 로의 요청 구현부 Using httpclient
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MembershipServiceAdapter implements GetMembershipPort {
+    private final CommonHttpClient commonHttpClient;
+    @Value("${service.membership.url}")
+    private String membershipServiceUrl;
+
+    @Override
+    public MembershipStatus getMembershipStatus(String membershipId) {
+        String url = String.join("/", membershipServiceUrl, "membership", membershipId);
+        try {
+            String response = commonHttpClient.sendGetRequest(url).body();
+            ObjectMapper mapper = new ObjectMapper();
+            // TODO: ObjectMapper 에러 처리, 에러 Response 규격처리 필요
+            try {
+                MembershipInfo membershipInfo = mapper.readValue(response, MembershipInfo.class);
+                return new MembershipStatus(membershipId, membershipInfo.isValid());
+            } catch (UnrecognizedPropertyException unrecognizedPropertyException) {
+                return new MembershipStatus(membershipId, false);
+            }
+        } catch (Exception e) {
+            log.error("Request Membership Service is failed cause {}", e.getMessage());
+            return new MembershipStatus(membershipId, false);
+        }
+
+    }
+
+}

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/out/kafka/TaskProducer.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/out/kafka/TaskProducer.java
@@ -1,0 +1,45 @@
+package com.sera.payapp.money.adapter.out.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sera.payapp.common.RechargingMoneyTask;
+import com.sera.payapp.money.application.port.out.dto.SendRechargingMoneyTaskPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class TaskProducer implements SendRechargingMoneyTaskPort {
+
+    @Value("${task.topic}")
+    private String topic;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(String key, RechargingMoneyTask task) {
+        String jsonStringToProduce;
+        try {
+            jsonStringToProduce = objectMapper.writeValueAsString(task);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing object: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        kafkaTemplate.send(topic, key, jsonStringToProduce).whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Error sending message: " + ex.getMessage());
+            } else {
+                log.info("Message sent successfully");
+            }
+        });
+    }
+
+    @Override
+    public void sendRechargingMoneyTaskPort(RechargingMoneyTask task) {
+        sendMessage(task.getTaskId(), task);
+    }
+}

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/out/persistence/MemberMoneyAdapter.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/out/persistence/MemberMoneyAdapter.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class MemberMoneyAdatper implements IncreaseMoneyPort {
+public class MemberMoneyAdapter implements IncreaseMoneyPort {
     private final SpringDataMemberMoneyRepository memberMoneyRepository;
 
 
@@ -18,7 +18,7 @@ public class MemberMoneyAdatper implements IncreaseMoneyPort {
     public MemberMoneyJpaEntity increaseMoney(MemberMoney.MembershipId membershipId, int increaseMoneyAmount) {
         Optional<MemberMoneyJpaEntity> entity = memberMoneyRepository.findByMembershipId(Long.valueOf(membershipId.getMembershipId()));
         if (entity.isEmpty()) {
-            return memberMoneyRepository.save(new MemberMoneyJpaEntity(membershipId.getMembershipId(), increaseMoneyAmount));
+            return memberMoneyRepository.save(new MemberMoneyJpaEntity(Long.valueOf(membershipId.getMembershipId()), increaseMoneyAmount));
         }
 
         MemberMoneyJpaEntity memberMoneyJpaEntity = entity.get();

--- a/money-service/src/main/java/com/sera/payapp/money/adapter/out/persistence/MemberMoneyJpaEntity.java
+++ b/money-service/src/main/java/com/sera/payapp/money/adapter/out/persistence/MemberMoneyJpaEntity.java
@@ -1,6 +1,8 @@
 package com.sera.payapp.money.adapter.out.persistence;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,11 +16,14 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MemberMoneyJpaEntity {
+    @Id
+    @GeneratedValue
     private Long memberMoneyId;
-    private String membershipId;
+
+    private Long membershipId;
     private int balance;
 
-    public MemberMoneyJpaEntity(String membershipId, int balance) {
+    public MemberMoneyJpaEntity(Long membershipId, int balance) {
         this.membershipId = membershipId;
         this.balance = balance;
     }

--- a/money-service/src/main/java/com/sera/payapp/money/application/port/in/IncreaseMoneyCommand.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/port/in/IncreaseMoneyCommand.java
@@ -1,14 +1,16 @@
 package com.sera.payapp.money.application.port.in;
 
+import com.sera.payapp.common.RechargingMoneyTask;
 import com.sera.payapp.common.SelfValidating;
+import com.sera.payapp.common.SubTask;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@EqualsAndHashCode
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -17,4 +19,38 @@ public class IncreaseMoneyCommand extends SelfValidating<IncreaseMoneyCommand> {
     private String targetMembershipId;
     @NotNull
     private int amount;
+
+    public SubTask toValidMemberTask() {
+        return SubTask.builder()
+                .membershipId(targetMembershipId)
+                .subTaskName("validMemberTask: 멤버쉽 유효성 검사")
+                .taskType("membership")
+                .status("ready")
+                .build();
+    }
+
+    public SubTask toValidBankAccountTask() {
+        return SubTask.builder()
+                .membershipId(targetMembershipId)
+                .subTaskName("validBankAccountTask: 뱅킹계좌 유효성 검사")
+                .taskType("banking")
+                .status("ready")
+                .build();
+    }
+
+    public RechargingMoneyTask toRechargeMoneyTask(List<SubTask> subTasks) {
+        return RechargingMoneyTask.builder()
+                .taskName("Increase Money Task / 머니 충전 Task")
+                .membershipId(targetMembershipId)
+                .subTasks(List.of(
+                        toValidMemberTask(),
+                        toValidBankAccountTask()
+                ))
+                .toBankName("우리은행")
+                .toBankAccountNumber("123-456-789")
+                .moneyAmount(amount)
+                .build();
+    }
 }
+
+

--- a/money-service/src/main/java/com/sera/payapp/money/application/port/out/GetMembershipPort.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/port/out/GetMembershipPort.java
@@ -1,0 +1,8 @@
+package com.sera.payapp.money.application.port.out;
+
+
+import com.sera.payapp.money.application.port.out.dto.MembershipStatus;
+
+public interface GetMembershipPort {
+    MembershipStatus getMembershipStatus(String membershipId);
+}

--- a/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/MembershipInfo.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/MembershipInfo.java
@@ -1,0 +1,16 @@
+package com.sera.payapp.money.application.port.out.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class MembershipInfo {
+    private String membershipId;
+    private String name;
+    private String email;
+    private String address;
+    @JsonProperty(value = "isValid")
+    private boolean isValid;
+    @JsonProperty(value = "isCorp")
+    private boolean isCorp;
+}

--- a/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/MembershipStatus.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/MembershipStatus.java
@@ -1,0 +1,12 @@
+package com.sera.payapp.money.application.port.out.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MembershipStatus {
+    private String membershipId;
+    private boolean isValid;
+}

--- a/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/SendRechargingMoneyTaskPort.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/port/out/dto/SendRechargingMoneyTaskPort.java
@@ -1,0 +1,10 @@
+package com.sera.payapp.money.application.port.out.dto;
+
+import com.sera.payapp.common.RechargingMoneyTask;
+
+/**
+ * 카프카로 머니충전에 들어가는 Task 를 보내는 포트
+ */
+public interface SendRechargingMoneyTaskPort {
+    void sendRechargingMoneyTaskPort(RechargingMoneyTask task);
+}

--- a/money-service/src/main/java/com/sera/payapp/money/application/service/IncreaseMoneyAsyncService.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/service/IncreaseMoneyAsyncService.java
@@ -1,11 +1,20 @@
 package com.sera.payapp.money.application.service;
 
+import com.sera.payapp.common.CountDownLatchManager;
 import com.sera.payapp.common.RechargingMoneyTask;
 import com.sera.payapp.common.SubTask;
 import com.sera.payapp.common.UseCase;
+import com.sera.payapp.money.adapter.out.persistence.MemberMoneyJpaEntity;
+import com.sera.payapp.money.adapter.out.persistence.MoneyChangingRequestJpaEntity;
+import com.sera.payapp.money.adapter.out.persistence.MoneyChangingRequestMapper;
 import com.sera.payapp.money.application.port.in.IncreaseMoneyCommand;
 import com.sera.payapp.money.application.port.in.IncreaseMoneyUseCase;
+import com.sera.payapp.money.application.port.out.IncreaseMoneyChangingRequestPort;
+import com.sera.payapp.money.application.port.out.IncreaseMoneyPort;
 import com.sera.payapp.money.application.port.out.dto.SendRechargingMoneyTaskPort;
+import com.sera.payapp.money.domain.ChangingMoneyStatus;
+import com.sera.payapp.money.domain.ChangingMoneyType;
+import com.sera.payapp.money.domain.MemberMoney;
 import com.sera.payapp.money.domain.MoneyChangingRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
@@ -13,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 @UseCase
 @Service
@@ -20,6 +30,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class IncreaseMoneyAsyncService implements IncreaseMoneyUseCase {
     private final SendRechargingMoneyTaskPort sendRechargingMoneyTaskPort;
+    private final IncreaseMoneyPort increaseMoneyPort;
+    private final IncreaseMoneyChangingRequestPort increaseMoneyChangingRequestPort;
+    private final MoneyChangingRequestMapper moneyChangingRequestMapper;
+    private final CountDownLatchManager countDownLatchManager;
 
 
     /**
@@ -36,13 +50,43 @@ public class IncreaseMoneyAsyncService implements IncreaseMoneyUseCase {
 
         List<SubTask> subTasks = Arrays.asList(validMemberTask, validBankAccountTask);
         RechargingMoneyTask task = command.toRechargeMoneyTask(subTasks);
-
+        String taskId = task.getTaskId();
         // 2. kafka 클러스터에 메세지 Produce
         sendRechargingMoneyTaskPort.sendRechargingMoneyTaskPort(task);
+        countDownLatchManager.addCountDownLatch(taskId);
 
+        // task 가 다 끝날때 까지 wait (blocking)
+        // task.id 로 매핑한 CountDownLatch 를 이용하여 task 가 다 끝나면 끝나는 쪽에서 countDown() 이 호출되면 여기서에서 await() 이 풀린다.
+        try {
+            countDownLatchManager.getCountDownLatch(taskId).await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         // 3-1. task-consumer: subtask 의 모든 status 가 ok 인지 확인하고 task 결과를 Produce
 
         // 4. task Result consume
+        String taskResult = countDownLatchManager.getDataForKey(taskId);
+        if(taskResult.equals("success")) {
+            // 5-1. task-result-consumer: task 결과가 success 이면, 충전금액을 증액한다.
+            MemberMoneyJpaEntity memberMoneyJpaEntity = increaseMoneyPort.increaseMoney(
+                    new MemberMoney.MembershipId(command.getTargetMembershipId()),
+                    command.getAmount()
+            );
+            if (memberMoneyJpaEntity != null) {
+                // MemberMoney 를 성공적으로 증액한 경우
+                MoneyChangingRequestJpaEntity moneyChangingRequestJpaEntity = increaseMoneyChangingRequestPort.increaseMoney(
+                        new MoneyChangingRequest.TargetMembershipId(command.getTargetMembershipId()),
+                        new MoneyChangingRequest.MoneyChangingType(ChangingMoneyType.INCREASING),
+                        new MoneyChangingRequest.ChangingMoneyAmount(command.getAmount()),
+                        new MoneyChangingRequest.LinkedStatusIsValid(true),
+                        new MoneyChangingRequest.MoneyChangingStatus(ChangingMoneyStatus.SUCCESS),
+                        new MoneyChangingRequest.Uuid(UUID.randomUUID()));
+                return moneyChangingRequestMapper.mapToDomainEntity(moneyChangingRequestJpaEntity);
+
+            }
+        } else {
+            // 5-2. task-result-consumer: task 결과가 fail 이면, 충전금액을 증액하지 않는다.
+        }
         // 5. consume ok, logic
 
         return null;

--- a/money-service/src/main/java/com/sera/payapp/money/application/service/IncreaseMoneyAsyncService.java
+++ b/money-service/src/main/java/com/sera/payapp/money/application/service/IncreaseMoneyAsyncService.java
@@ -1,0 +1,52 @@
+package com.sera.payapp.money.application.service;
+
+import com.sera.payapp.common.RechargingMoneyTask;
+import com.sera.payapp.common.SubTask;
+import com.sera.payapp.common.UseCase;
+import com.sera.payapp.money.application.port.in.IncreaseMoneyCommand;
+import com.sera.payapp.money.application.port.in.IncreaseMoneyUseCase;
+import com.sera.payapp.money.application.port.out.dto.SendRechargingMoneyTaskPort;
+import com.sera.payapp.money.domain.MoneyChangingRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@UseCase
+@Service
+@Primary
+@RequiredArgsConstructor
+public class IncreaseMoneyAsyncService implements IncreaseMoneyUseCase {
+    private final SendRechargingMoneyTaskPort sendRechargingMoneyTaskPort;
+
+
+    /**
+     * 카프카를 이용하여 비동기로 증액 요청을 처리하는 서비스
+     * 멤버쉽 유효성 체크, 게좌(충전금액을 빼내는) 유효성 체크를 REST API 가 아니라 카프카를 이용하여 비동기로 메세지를 발생하여 처리한다.
+     */
+    @Override
+    public MoneyChangingRequest increaseMoney(IncreaseMoneyCommand command) {
+        // 1-1. subTask: 멤버쉽 유효성 체크
+        SubTask validMemberTask = command.toValidMemberTask();
+        // 1-2. subTask: 게좌(충전금액을 빼내는) 유효성 체크
+        SubTask validBankAccountTask = command.toValidBankAccountTask();
+        // TODO: 1-3 subTask: 충전할 금액에 대한 유효성 체크
+
+        List<SubTask> subTasks = Arrays.asList(validMemberTask, validBankAccountTask);
+        RechargingMoneyTask task = command.toRechargeMoneyTask(subTasks);
+
+        // 2. kafka 클러스터에 메세지 Produce
+        sendRechargingMoneyTaskPort.sendRechargingMoneyTaskPort(task);
+
+        // 3-1. task-consumer: subtask 의 모든 status 가 ok 인지 확인하고 task 결과를 Produce
+
+        // 4. task Result consume
+        // 5. consume ok, logic
+
+        return null;
+
+    }
+
+}

--- a/money-service/src/main/resources/application.yml
+++ b/money-service/src/main/resources/application.yml
@@ -2,6 +2,9 @@ kafka:
   clusters:
     bootstrapservers: localhost:9092
 logging.topic: sera.payapp.logging.out.stdout
-
+task.topic: sera.task.topic
+service:
+  membership:
+    url: http://localhost:8081
 server:
   port: 8082

--- a/money-service/src/main/resources/application.yml
+++ b/money-service/src/main/resources/application.yml
@@ -3,6 +3,7 @@ kafka:
     bootstrapservers: localhost:9092
 logging.topic: sera.payapp.logging.out.stdout
 task.topic: sera.task.topic
+task.result.topic: sera.task.result.topic
 service:
   membership:
     url: http://localhost:8081

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,5 @@ include 'common'
 include 'banking-service'
 include 'money-service'
 include 'logging-consumer'
+include 'task-consumer'
 

--- a/task-consumer/build.gradle
+++ b/task-consumer/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'com.sera.payapp.task-consumer'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
+
+    implementation project(path: ':common')
+
+    runtimeOnly 'com.h2database:h2'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/MessageListenerContainerConfig.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/MessageListenerContainerConfig.java
@@ -1,0 +1,50 @@
+package com.sera.payapp.taskconsumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class MessageListenerContainerConfig {
+
+    @Value("${kafka.clusters.bootstrapservers}")
+    private String bootstrapServers;
+    @Value("${task.topic}")
+    private String topic;
+
+    private final ObjectMapper objectMapper;
+    private final TaskResultProducer taskResultProducer;
+
+    @Bean
+    public KafkaMessageListenerContainer<String, String> kafkaMessageListenerContainer() {
+        ContainerProperties containerProperties = new ContainerProperties(topic);
+        containerProperties.setAckMode(ContainerProperties.AckMode.RECORD);
+        containerProperties.setGroupId("task-group");
+        containerProperties.setMessageListener(new TaskConsumer(objectMapper, taskResultProducer));
+        return new KafkaMessageListenerContainer<>(consumerFactory(), containerProperties);
+    }
+
+    public ConsumerFactory<String, String> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(props());
+    }
+
+    private Map<String, Object> props() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return props;
+    }
+}

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
@@ -1,0 +1,58 @@
+package com.sera.payapp.taskconsumer;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sera.payapp.common.RechargingMoneyTask;
+import com.sera.payapp.common.SubTask;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.listener.MessageListener;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TaskConsumer
+        implements MessageListener<String, String> {
+
+    private final ObjectMapper objectMapper;
+    private final TaskResultProducer taskResultProducer;
+
+    @Override
+    public void onMessage(ConsumerRecord<String, String> data) {
+//        Received message.key: 886e9735-de87-4c6b-b085-495c5a4ab0ed,
+//        message.value: {"taskId":"886e9735-de87-4c6b-b085-495c5a4ab0ed",
+//        "taskName":"Increase Money Task / 머니 충전 Task",
+//        "membershipId":null,
+//        "subTasks":[
+//        {"membershipId":null,
+//        "subTaskName":"validMemberTask: 멤버쉽 유효성 검사",
+//        "taskType":"membership","status":"ready"},
+//        {"membershipId":null,
+//        "subTaskName":"validBankAccountTask: 뱅킹계좌 유효성 검사",
+//        "taskType":"banking",
+//        "status":"ready"}
+//        ],
+//        "toBankName":"우리은행","toBankAccountNumber":"123-456-789","moneyAmount":0}
+        RechargingMoneyTask task;
+        try {
+            task = objectMapper.readValue(data.value(), RechargingMoneyTask.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        List<SubTask> subTasks = task.getSubTasks();
+
+        boolean taskResult = true;
+        for (SubTask subTask : subTasks) {
+            // TODO: validation membership
+            // TODO: validation banking
+            // TODO: 실제로 external port, adapter 를 통해 validation 을 수행하고 결과를 받아온다.
+            subTask.setStatus("success");
+        }
+        if (taskResult) {
+            this.taskResultProducer.sendMessage(task.getTaskId(), task);
+        }
+    }
+}

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
@@ -12,6 +12,10 @@ import org.springframework.kafka.listener.MessageListener;
 
 import java.util.List;
 
+/**
+ * 발행된 RechargingMoneyTask 메세지를 받아서 처리하는 Consumer
+ * 태스트에 해당하는 작업(internal Request) 를 수행 후 받은 작업을 완료했다는 메세지(set task.status) 를 발행한다.
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class TaskConsumer

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumer.java
@@ -52,7 +52,7 @@ public class TaskConsumer
             subTask.setStatus("success");
         }
         if (taskResult) {
-            this.taskResultProducer.sendMessage(task.getTaskId(), task);
+            this.taskResultProducer.sendTaskResult(task);
         }
     }
 }

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumerApplication.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskConsumerApplication.java
@@ -1,0 +1,13 @@
+package com.sera.payapp.taskconsumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TaskConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TaskConsumerApplication.class, args);
+    }
+
+}

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
@@ -1,0 +1,39 @@
+package com.sera.payapp.taskconsumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sera.payapp.common.RechargingMoneyTask;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class TaskResultProducer {
+
+    @Value("${task.result.topic}")
+    private String topic;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(String key, RechargingMoneyTask task) {
+        String jsonStringToProduce;
+        try {
+            jsonStringToProduce = objectMapper.writeValueAsString(task);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing object: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        kafkaTemplate.send(topic, key, jsonStringToProduce).whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Error sending message: " + ex.getMessage());
+            } else {
+                log.info("Message sent successfully");
+            }
+        });
+    }
+}

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
@@ -19,6 +19,7 @@ public class TaskResultProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
 
+    // task.status 가 ready 이면 안됨. status 는 success, fail 만 가능
     public void sendTaskResult(RechargingMoneyTask task) {
         String jsonStringToProduce;
         try {

--- a/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
+++ b/task-consumer/src/main/java/com/sera/payapp/taskconsumer/TaskResultProducer.java
@@ -19,7 +19,7 @@ public class TaskResultProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
 
-    public void sendMessage(String key, RechargingMoneyTask task) {
+    public void sendTaskResult(RechargingMoneyTask task) {
         String jsonStringToProduce;
         try {
             jsonStringToProduce = objectMapper.writeValueAsString(task);
@@ -28,6 +28,7 @@ public class TaskResultProducer {
             throw new RuntimeException(e);
         }
 
+        String key = task.getTaskId();
         kafkaTemplate.send(topic, key, jsonStringToProduce).whenComplete((result, ex) -> {
             if (ex != null) {
                 log.error("Error sending message: " + ex.getMessage());

--- a/task-consumer/src/main/resources/application.yml
+++ b/task-consumer/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+kafka:
+  clusters:
+    bootstrapservers: localhost:9092
+task.topic: sera.task.topic
+task.result.topic: sera.task.result.topic
+server:
+  port: 8011


### PR DESCRIPTION
* 머니 증액 요청을 카프카를 이용하여 비동기 방식으로 처리
* IncreaseMoneyUseCase Interface 에서 기존이 동기방식(IncreaseMoneyService)에서 IncreaseMoneyAsyncService 로 교체함(@Primary 사용)
* 머니증액에서 membership, account validation 요청을 kafka 로 Task Topic 발행 후, Task결과를 CountLatch.countDown() 함수로 트리거 발생시켜 성공, 실패에 따른 처리

